### PR TITLE
Feature/to map

### DIFF
--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1213,13 +1213,9 @@ public class QuickJSTest {
     @Test
     public void testObjectToMapFilter() {
         QuickJSContext context = createContext();
-        HashMap<String, Object> map = context.getGlobalObject().toMap(new MapFilter() {
-            @Override
-            public boolean shouldSkipKey(String key, long pointer, Object extra) {
-                assertEquals("test", extra.toString());
-                return key.equals("Infinity");
-            }
-
+        HashMap<String, Object> map = context.getGlobalObject().toMap((key, pointer, extra) -> {
+            assertEquals("test", extra.toString());
+            return key.equals("Infinity");
         }, "test");
         System.out.println(map.toString());
         assertEquals("{NaN=NaN, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, undefined=null}", map.toString());

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -19,6 +19,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1206,6 +1207,20 @@ public class QuickJSTest {
         array.release();
 
         assertEquals("{a={a=123, b=[1, 2]}, b=[{a={c=xxx}}, 2, qqq, 1.22], Infinity=-9223372036854775808, NaN=NaN, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, undefined=null}", context.getGlobalObject().toMap().toString());
+        context.destroy();
+    }
+
+    @Test
+    public void testObjectToMapFilter() {
+        QuickJSContext context = createContext();
+        HashMap<String, Object> map = context.getGlobalObject().toMap(new MapFilter() {
+            @Override
+            public boolean isReadable(String key) {
+                return !key.equals("Infinity");
+            }
+        });
+        System.out.println(map.toString());
+        assertEquals("{NaN=NaN, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, undefined=null}", map.toString());
         context.destroy();
     }
 

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1215,10 +1215,12 @@ public class QuickJSTest {
         QuickJSContext context = createContext();
         HashMap<String, Object> map = context.getGlobalObject().toMap(new MapFilter() {
             @Override
-            public boolean isReadable(String key) {
-                return !key.equals("Infinity");
+            public boolean shouldSkipKey(String key, long pointer, Object extra) {
+                assertEquals("test", extra.toString());
+                return key.equals("Infinity");
             }
-        });
+
+        }, "test");
         System.out.println(map.toString());
         assertEquals("{NaN=NaN, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, undefined=null}", map.toString());
         context.destroy();

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1194,4 +1194,19 @@ public class QuickJSTest {
         context.destroy();
     }
 
+    @Test
+    public void testObjectToMap() {
+        QuickJSContext context = createContext();
+        JSObject ret = (JSObject) context.evaluate("var a = {'a': '123', 'b': [1, 2]};a.c = a;;a;");
+        assertEquals("{a=123, b=[1, 2]}", ret.toMap().toString());
+        ret.release();
+
+        JSArray array = (JSArray) context.evaluate("var b = [{a: { c : 'xxx'}}, 2, 'qqq', 1.22]; b.push(b); b;");
+        assertEquals("[{a={c=xxx}}, 2, qqq, 1.22]", array.toArray().toString());
+        array.release();
+
+        assertEquals("{a={a=123, b=[1, 2]}, b=[{a={c=xxx}}, 2, qqq, 1.22], Infinity=-9223372036854775808, NaN=NaN, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, undefined=null}", context.getGlobalObject().toMap().toString());
+        context.destroy();
+    }
+
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
@@ -1,5 +1,8 @@
 package com.whl.quickjs.wrapper;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 public interface JSObject {
 
     void setStackTrace(Throwable trace);
@@ -51,4 +54,8 @@ public interface JSObject {
      * 引用计数减一，目前仅将对象返回到 JavaScript 中的场景中使用。
      */
     void decrementRefCount();
+
+    HashMap<String, Object> toMap();
+
+    ArrayList<Object> toArray();
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
@@ -61,4 +61,6 @@ public interface JSObject {
 
     HashMap<String, Object> toMap(MapFilter filter);
     ArrayList<Object> toArray(MapFilter filter);
+    HashMap<String, Object> toMap(MapFilter filter, Object extra);
+    ArrayList<Object> toArray(MapFilter filter, Object extra);
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
@@ -58,4 +58,7 @@ public interface JSObject {
     HashMap<String, Object> toMap();
 
     ArrayList<Object> toArray();
+
+    HashMap<String, Object> toMap(MapFilter filter);
+    ArrayList<Object> toArray(MapFilter filter);
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapFilter.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapFilter.java
@@ -5,6 +5,6 @@ package com.whl.quickjs.wrapper;
  */
 public interface MapFilter {
 
-    boolean isReadable(String key);
+    boolean shouldSkipKey(String key, long pointer, Object extra);
 
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapFilter.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapFilter.java
@@ -1,0 +1,10 @@
+package com.whl.quickjs.wrapper;
+
+/**
+ * Created by Harlon Wang on 2024/9/27.
+ */
+public interface MapFilter {
+
+    boolean isReadable(String key);
+
+}

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapFilter.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapFilter.java
@@ -5,6 +5,13 @@ package com.whl.quickjs.wrapper;
  */
 public interface MapFilter {
 
+    /**
+     * toMap 转换期间是否需要过滤指定 key
+     * @param key 需要过滤的 key
+     * @param pointer 当前 key 所属对象的指针地址
+     * @param extra 扩展参数，如果你需要一些额外信息，可通过 toMap(..., extra) 传递该参数
+     * @return 是否需要过滤该 key
+     */
     boolean shouldSkipKey(String key, long pointer, Object extra);
 
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
@@ -38,7 +38,7 @@ public class QuickJSArray extends QuickJSObject implements JSArray {
 
     @Override
     public HashMap<String, Object> toMap(MapFilter filter) {
-        throw new UnsupportedOperationException("Array types are not yet supported for conversion to map. You should use toArray.");
+        return toMap(filter, null);
     }
 
     @Override
@@ -48,10 +48,20 @@ public class QuickJSArray extends QuickJSObject implements JSArray {
 
     @Override
     public ArrayList<Object> toArray(MapFilter filter) {
+        return toArray(filter, null);
+    }
+
+    @Override
+    public ArrayList<Object> toArray(MapFilter filter, Object extra) {
         ArrayList<Object> arrayList = new ArrayList<>(length());
         HashSet<Long> circulars = new HashSet<>();
-        convertToMap(this, arrayList, circulars, filter);
+        convertToMap(this, arrayList, circulars, filter, extra);
         circulars.clear();
         return arrayList;
+    }
+
+    @Override
+    public HashMap<String, Object> toMap(MapFilter filter, Object extra) {
+        throw new UnsupportedOperationException("Array types are not yet supported for conversion to map. You should use toArray.");
     }
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
@@ -33,14 +33,24 @@ public class QuickJSArray extends QuickJSObject implements JSArray {
 
     @Override
     public HashMap<String, Object> toMap() {
+        return toMap(null);
+    }
+
+    @Override
+    public HashMap<String, Object> toMap(MapFilter filter) {
         throw new UnsupportedOperationException("Array types are not yet supported for conversion to map. You should use toArray.");
     }
 
     @Override
     public ArrayList<Object> toArray() {
+        return toArray(null);
+    }
+
+    @Override
+    public ArrayList<Object> toArray(MapFilter filter) {
         ArrayList<Object> arrayList = new ArrayList<>(length());
         HashSet<Long> circulars = new HashSet<>();
-        convertToMap(this, arrayList, circulars);
+        convertToMap(this, arrayList, circulars, filter);
         circulars.clear();
         return arrayList;
     }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
@@ -2,6 +2,7 @@ package com.whl.quickjs.wrapper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 
 /**
  * Created by Harlon Wang on 2024/2/13.
@@ -38,7 +39,8 @@ public class QuickJSArray extends QuickJSObject implements JSArray {
     @Override
     public ArrayList<Object> toArray() {
         ArrayList<Object> arrayList = new ArrayList<>(length());
-        convertToMap(this, arrayList);
+        HashSet<Long> circulars = new HashSet<>();
+        convertToMap(this, arrayList, circulars);
         circulars.clear();
         return arrayList;
     }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
@@ -1,5 +1,8 @@
 package com.whl.quickjs.wrapper;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 /**
  * Created by Harlon Wang on 2024/2/13.
  */
@@ -25,5 +28,18 @@ public class QuickJSArray extends QuickJSObject implements JSArray {
     public void set(Object value, int index) {
         checkRefCountIsZero();
         getContext().set(this, value, index);
+    }
+
+    @Override
+    public HashMap<String, Object> toMap() {
+        throw new UnsupportedOperationException("Array types are not yet supported for conversion to map. You should use toArray.");
+    }
+
+    @Override
+    public ArrayList<Object> toArray() {
+        ArrayList<Object> arrayList = new ArrayList<>(length());
+        convertToMap(this, arrayList);
+        circulars.clear();
+        return arrayList;
     }
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSFunction.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSFunction.java
@@ -1,5 +1,8 @@
 package com.whl.quickjs.wrapper;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+
 /**
  * Created by Harlon Wang on 2024/2/12.
  */
@@ -60,4 +63,13 @@ public class QuickJSFunction extends QuickJSObject implements JSFunction {
         }
     }
 
+    @Override
+    public HashMap<String, Object> toMap() {
+        throw new UnsupportedOperationException("JSFunction types do not support conversion to map or array.");
+    }
+
+    @Override
+    public ArrayList<Object> toArray() {
+        throw new UnsupportedOperationException("JSFunction types do not support conversion to map or array.");
+    }
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSObject.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSObject.java
@@ -254,25 +254,37 @@ public class QuickJSObject implements JSObject {
 
     @Override
     public HashMap<String, Object> toMap(MapFilter filter) {
+        return toMap(filter, null);
+    }
+
+    @Override
+    public HashMap<String, Object> toMap(MapFilter filter, Object extra) {
         HashMap<String, Object> objectMap = new HashMap<>();
         HashSet<Long> circulars = new HashSet<>();
-        convertToMap(this, objectMap, circulars, filter);
+        convertToMap(this, objectMap, circulars, filter, extra);
         circulars.clear();
         return objectMap;
     }
 
     @Override
-    public ArrayList<Object> toArray(MapFilter filter) {
+    public ArrayList<Object> toArray(MapFilter filter, Object extra) {
         throw new UnsupportedOperationException("Object types are not yet supported for conversion to array. You should use toMap.");
+
     }
 
-    protected void convertToMap(Object target, Object map, HashSet<Long> circulars, MapFilter filter) {
-        if (circulars.contains(((JSObject) target).getPointer())) {
+    @Override
+    public ArrayList<Object> toArray(MapFilter filter) {
+        return toArray(filter, null);
+    }
+
+    protected void convertToMap(Object target, Object map, HashSet<Long> circulars, MapFilter filter, Object extra) {
+        long pointer = ((JSObject) target).getPointer();
+        if (circulars.contains(pointer)) {
             // Circular reference objects, no processing needed.
             return;
         }
 
-        circulars.add(((JSObject) target).getPointer());
+        circulars.add(pointer);
 
         boolean isArray = target instanceof JSArray;
         JSArray array = isArray ? (JSArray) target : ((JSObject) target).getNames();
@@ -284,7 +296,7 @@ public class QuickJSObject implements JSObject {
                 value = array.get(i);
             } else {
                 key = (String) array.get(i);
-                if (filter != null && !filter.isReadable(key)) {
+                if (filter != null && filter.shouldSkipKey(key, pointer, extra)) {
                     continue;
                 }
                 value = ((JSObject) target).getProperty(key);
@@ -298,7 +310,7 @@ public class QuickJSObject implements JSObject {
 
             if (value instanceof JSArray) {
                 ArrayList<Object> list = new ArrayList<>(((JSArray) value).length());
-                convertToMap(value, list, circulars, filter);
+                convertToMap(value, list, circulars, filter, extra);
                 if (!list.isEmpty()) {
                     if (map instanceof HashMap) {
                         ((HashMap<String, Object>) map).put(key, list);
@@ -312,7 +324,7 @@ public class QuickJSObject implements JSObject {
 
             if (value instanceof JSObject) {
                 HashMap<String, Object> valueMap = new HashMap<>();
-                convertToMap(value, valueMap, circulars, filter);
+                convertToMap(value, valueMap, circulars, filter, extra);
                 if (!valueMap.isEmpty()) {
                     if (map instanceof HashMap) {
                         ((HashMap<String, Object>) map).put(key, valueMap);


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery的总结

添加方法以将JavaScript对象和数组转换为Java集合，并可选进行过滤，处理循环引用，并确保适当管理不支持的类型。引入测试以验证这些新功能。

新功能：
- 在`QuickJSObject`和`QuickJSArray`类中引入`toMap`和`toArray`方法，将JavaScript对象和数组分别转换为Java的HashMap和ArrayList。
- 在转换过程中添加使用`MapFilter`接口进行键过滤的支持。

增强功能：
- 在转换过程中实现循环引用的处理，以防止无限循环。
- 提供对不支持类型（如`JSFunction`）的自定义处理，在转换过程中抛出`UnsupportedOperationException`。

测试：
- 为`toMap`和`toArray`方法添加测试，以验证JavaScript对象和数组的正确转换，包括循环引用和过滤功能的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add methods to convert JavaScript objects and arrays to Java collections with optional filtering, handle circular references, and ensure unsupported types are managed appropriately. Introduce tests to validate these new functionalities.

New Features:
- Introduce `toMap` and `toArray` methods in `QuickJSObject` and `QuickJSArray` classes to convert JavaScript objects and arrays to Java HashMaps and ArrayLists, respectively.
- Add support for filtering keys during the conversion process using the `MapFilter` interface.

Enhancements:
- Implement handling of circular references in the conversion process to prevent infinite loops.
- Provide custom handling for unsupported types like `JSFunction` during conversion, throwing an `UnsupportedOperationException`.

Tests:
- Add tests for `toMap` and `toArray` methods to verify correct conversion of JavaScript objects and arrays, including tests for circular references and filtering functionality.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->