### PR TITLE
Feature/2.3.0

### DIFF
--- a/native/cpp/quickjs_wrapper.cpp
+++ b/native/cpp/quickjs_wrapper.cpp
@@ -169,7 +169,9 @@ static char *jsModuleNormalizeFunc(JSContext *ctx, const char *module_base_name,
     env->DeleteLocalRef(moduleLoader);
 
     // todo 这里作为返回值，没有调用 ReleaseStringUTFChars，quickjs.c 里面会对 char* 进行释放，需要 check 下是否有释放？
-    return (char *) env->GetStringUTFChars((jstring) result, nullptr);
+    auto ret = (char *) env->GetStringUTFChars((jstring) result, nullptr);
+    env->DeleteLocalRef(result);
+    return ret;
 }
 
 static JSModuleDef *

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -67,7 +67,6 @@ public class QuickJSTest {
     public static QuickJSContext createContext() {
         QuickJSContext context = QuickJSContext.create();
         context.setConsole(new LogcatConsole("console-test"));
-        context.setLeakDetectionListener((leak, stringValue) -> Log.e("leak-object", stringValue));
         return context;
     }
 
@@ -1219,6 +1218,21 @@ public class QuickJSTest {
         }, "test");
         System.out.println(map.toString());
         assertEquals("{NaN=NaN, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, undefined=null}", map.toString());
+        context.destroy();
+    }
+
+    @Test
+    public void testObjectLeakDetection() {
+        QuickJSContext context = createContext();
+        context.setLeakDetectionListener((leak, stringValue) -> {
+            assertEquals(stringValue, "{ name: 'leak1' }");
+        });
+
+        // 泄漏场景
+        JSObject o = context.createNewJSObject();
+        o.setProperty("name", "leak1");
+        // o.release();
+
         context.destroy();
     }
 

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
@@ -291,17 +291,20 @@ public class QuickJSContext implements Closeable {
     }
 
     public void releaseObjectRecords(boolean needRelease) {
+        JSFunction format = getGlobalObject().getJSFunction("format");
+
         // 检测是否有未被释放引用的对象，如果有的话，根据计数释放一下
         Iterator<JSObject> objectIterator = objectRecords.iterator();
         while (objectIterator.hasNext()) {
             JSObject object = objectIterator.next();
-            // 全局对象交由引擎层会回收，这里先过滤掉
-            if (!object.isRefCountZero() && object != getGlobalObject()) {
+
+            // 这里需要过滤掉 getGlobalObject 和 format
+            // 1. getGlobalObject 全局对象不会主动释放，引擎销毁会回收
+            // 2. format 用来格式化内容，会在迭代完释放掉，这里过滤掉
+            if (!object.isRefCountZero() && object != getGlobalObject() && object != format) {
                 int refCount = object.getRefCount();
                 if (leakDetectionListener != null) {
-                    JSFunction format = getGlobalObject().getJSFunction("format");
                     String value = (String) format.call(object);
-                    format.release();
                     leakDetectionListener.notifyLeakDetected(object, value);
                 }
 
@@ -318,6 +321,8 @@ public class QuickJSContext implements Closeable {
                 }
             }
         }
+
+        format.release();
     }
 
     public List<JSObject> getObjectRecords() {

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
@@ -292,7 +292,6 @@ public class QuickJSContext implements Closeable {
 
     public void releaseObjectRecords(boolean needRelease) {
         // 检测是否有未被释放引用的对象，如果有的话，根据计数释放一下
-        JSFunction format = getGlobalObject().getJSFunction("format");
         Iterator<JSObject> objectIterator = objectRecords.iterator();
         while (objectIterator.hasNext()) {
             JSObject object = objectIterator.next();
@@ -300,10 +299,9 @@ public class QuickJSContext implements Closeable {
             if (!object.isRefCountZero() && object != getGlobalObject()) {
                 int refCount = object.getRefCount();
                 if (leakDetectionListener != null) {
-                    String value = null;
-                    if (format != null) {
-                        value = (String) format.call(object);
-                    }
+                    JSFunction format = getGlobalObject().getJSFunction("format");
+                    String value = (String) format.call(object);
+                    format.release();
                     leakDetectionListener.notifyLeakDetected(object, value);
                 }
 


### PR DESCRIPTION
## Summary by Sourcery

通过在使用后释放 'format' JSFunction 并删除 jsModuleNormalizeFunc 中的本地引用，增强 QuickJSContext 的内存管理。添加一个测试用例以验证对象泄漏检测功能。

Bug 修复：
- 通过确保在 QuickJSContext 中使用后释放 'format' JSFunction 来修复潜在的内存泄漏。
- 正确删除 jsModuleNormalizeFunc 中对 'result' 的本地引用以防止内存泄漏。

测试：
- 添加一个新的测试用例 'testObjectLeakDetection' 以验证 QuickJSContext 中的泄漏检测机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance memory management in QuickJSContext by releasing the 'format' JSFunction after use and deleting local references in jsModuleNormalizeFunc. Add a test case to verify object leak detection functionality.

Bug Fixes:
- Fix potential memory leak by ensuring the 'format' JSFunction is released after use in QuickJSContext.
- Correctly delete local reference to 'result' in jsModuleNormalizeFunc to prevent memory leaks.

Tests:
- Add a new test case 'testObjectLeakDetection' to verify the leak detection mechanism in QuickJSContext.

</details>