### PR TITLE
添加 byte[]与 ArrayBuffer 互相转换的功能

### DIFF
--- a/native/cpp/quickjs_context_jni.cpp
+++ b/native/cpp/quickjs_context_jni.cpp
@@ -271,3 +271,17 @@ Java_com_whl_quickjs_wrapper_QuickJSContext_getOwnPropertyNames(JNIEnv *env, job
     auto wrapper = reinterpret_cast<QuickJSWrapper*>(context);
     return wrapper->getOwnPropertyNames(env, thiz, obj_value);
 }
+
+extern "C"
+JNIEXPORT jobject JNICALL
+Java_com_whl_quickjs_wrapper_QuickJSContext_newArrayBuffer(JNIEnv *env, jobject thiz, jlong context, jbyteArray value) {
+    auto wrapper = reinterpret_cast<QuickJSWrapper*>(context);
+    return wrapper->newArrayBuffer(env, thiz, value);
+}
+
+extern "C"
+JNIEXPORT jbyteArray JNICALL
+Java_com_whl_quickjs_wrapper_QuickJSContext_arrayBufferToByteArray(JNIEnv *env, jobject thiz, jlong context, jlong value) {
+    auto wrapper = reinterpret_cast<QuickJSWrapper*>(context);
+    return wrapper->arrayBufferToByteArray(env, thiz, value);
+}

--- a/native/cpp/quickjs_wrapper.h
+++ b/native/cpp/quickjs_wrapper.h
@@ -42,6 +42,7 @@ public:
     jclass quickjsContextClass;
     jclass moduleLoaderClass;
     jclass creatorClass;
+    jclass byteArrayClass;
     JSValue ownPropertyNames;
 
     jmethodID booleanValueOf;
@@ -90,6 +91,9 @@ public:
     jobject evaluateModule(JNIEnv *env, jobject thiz, jstring script, jstring file_name);
 
     jobject getOwnPropertyNames(JNIEnv *env, jobject thiz, jlong obj);
+
+    jobject newArrayBuffer(JNIEnv *env, jobject thiz, jbyteArray value);
+    jbyteArray arrayBufferToByteArray(JNIEnv *env, jobject thiz, jlong obj);
 };
 
 #endif //QUICKJS_TEST_CONTEXT_WRAPPER_H

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/JSArrayBufferTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/JSArrayBufferTest.java
@@ -1,0 +1,31 @@
+package com.whl.quickjs.wrapper;
+
+import com.whl.quickjs.android.QuickJSLoader;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class JSArrayBufferTest {
+    @Test
+    public void toByteArray() {
+        QuickJSLoader.init();
+        QuickJSContext context = QuickJSContext.create();
+        byte[] bytes = "test测试".getBytes();
+        JSObject buffer = context.newArrayBuffer(bytes);
+        assertEquals(bytes, context.toByteArray(buffer));
+        buffer.release();
+        context.destroy();
+    }
+
+    @Test
+    public void jsArrayBuffer() {
+        QuickJSLoader.init();
+        QuickJSContext context = QuickJSContext.create();
+        byte[] bytes = "test测试".getBytes();
+        //new TextEncoder().encode("test测试").buffer
+        JSObject buffer = (JSObject) context.evaluate("new Uint8Array([116, 101, 115, 116, 230, 181, 139, 232, 175, 149]).buffer");
+        assertEquals(bytes, context.toByteArray(buffer));
+        buffer.release();
+        context.destroy();
+    }
+}

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
@@ -570,6 +570,18 @@ public class QuickJSContext implements Closeable {
         return getOwnPropertyNames(context, object.getPointer());
     }
 
+    public byte[] toByteArray(JSObject object) {
+        checkSameThread();
+        checkDestroyed();
+        return arrayBufferToByteArray(context, object.getPointer());
+    }
+
+    public JSObject newArrayBuffer(byte[] data) {
+        checkSameThread();
+        checkDestroyed();
+        return newArrayBuffer(context, data);
+    }
+
     // runtime
     private native long createRuntime();
     private native void setMaxStackSize(long runtime, int size); // The default is 1024 * 256, and 0 means unlimited.
@@ -601,4 +613,6 @@ public class QuickJSContext implements Closeable {
 
     // destroy context and runtime
     private native void destroyContext(long context);
+    private native JSObject newArrayBuffer(long context, byte[] value);
+    private native byte[] arrayBufferToByteArray(long context, long objValue);
 }


### PR DESCRIPTION
简单支持 ArrayBuffer 和 byte[] 相互转换。
```java
//写入 byte[] 
byte[] bytes ;
JSObject obj = context.createNewJSObject();
obj.setProperty(obj, "data", bytes);
//或者
JSObject  data = context.newArrayBuffer(bytes);
obj.setProperty("data ",  data);

//读取 byte[] 
byte[]  bs = context.toByteArray(data);

//如果要判断一个 JSObject  是否是 ArrayBuffer 可以
public static boolean isArrayBuffer(JSObject object) {
    if (object == null) return false;
    Object constructor = object.getProperty("constructor");
    if (constructor instanceof JSObject) {
        JSObject jsObject = (JSObject) constructor;
        boolean isArrayBuffer = "ArrayBuffer".equals(jsObject.getProperty("name"));
        jsObject.release();
        return isArrayBuffer;
    }
    return false;
}
```

## Summary by Sourcery

新功能：
- 在 QuickJS 上下文中引入在字节数组和 ArrayBuffer 之间转换的功能，允许字节数组转换为 ArrayBuffer，反之亦然。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce functionality to convert between byte arrays and ArrayBuffer in the QuickJS context, allowing byte arrays to be converted to ArrayBuffer and vice versa.

</details>