### PR TITLE
支持 ArrayBuffer 和 byte 类型互转

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.4.0 *(2024-11-14)*
+- 新增方法: 获取使用内存的大小信息（getMemoryUsedSize）
+- 支持 ArrayBuffer 转为 Byte 数组（深拷贝，对性能有一些影响）
+
 ## 2.2.1 *(2024-09-29)*
 - JSObject 增加 toMap 方法，支持转 HashMap 类型
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ context.setConsole(your console implementation.);
 - `int`
 - `long`
 - `double`
+- `byte[]` <=> ArrayBuffer
 - `String`
 - `null`
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ QuickJS wrapper for Android/JVM.
 - Supports converting JS object types to Java HashMap.
 - ESModule (import, export)
 
+Experimental Features Stability not guaranteed.
+- Supports ArrayBuffer to a byte array type.
+
 ## Download
 
 [![Maven Central](https://img.shields.io/maven-central/v/wang.harlon.quickjs/wrapper-android.svg?label=Maven%20Central&color=blue)](https://search.maven.org/search?q=g:%22wang.harlon.quickjs%22%20AND%20a:%22wrapper-android%22)
@@ -99,16 +102,17 @@ context.setConsole(your console implementation.);
 ### Supported Types
 
 #### Java and JavaScript can directly convert to each other for the following basic types
-| JavaScript | Java            |
-|------------|-----------------|
-| null       | null            |
-| undefined  | null            |
-| boolean    | Boolean         |
-| Number     | Long/Int/Double |
-| string     | String          |
-| Array      | JSArray         |
-| object     | JSObject        |
-| Function   | JSFunction      |
+| JavaScript  | Java              |
+|-------------|-------------------|
+| null        | null              |
+| undefined   | null              |
+| boolean     | Boolean           |
+| Number      | Long/Int/Double   |
+| string      | String            |
+| Array       | JSArray           |
+| object      | JSObject          |
+| Function    | JSFunction        |
+| ArrayBuffer | byte[](Deep copy) |
 
 Since JavaScript doesn't have a `long` type, additional information about `long`:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ QuickJS wrapper for Android/JVM.
 - JavaScript exception handler
 - Compile bytecode
 - Supports converting JS object types to Java HashMap.
-
-Experimental Features Stability not guaranteed.
 - ESModule (import, export)
 
 ## Download
@@ -85,18 +83,12 @@ QuickJSLoader.init();
 
 ```Java
 QuickJSContext context = QuickJSContext.create();
-```
 
-### Destroy QuickJSContext
-
-```Java
-context.destroy();
-```
-
-### Evaluating JavaScript
-
-```Java
+// evaluating JavaScript
 context.evaluate("var a = 1 + 2;");
+
+// destroy QuickJSContext
+context.destroy();
 ```
 
 ### Console Support
@@ -107,29 +99,27 @@ context.setConsole(your console implementation.);
 ### Supported Types
 
 #### Java and JavaScript can directly convert to each other for the following basic types
-- `boolean`
-- `int`
-- `long`
-- `double`
-- `byte[]` <=> ArrayBuffer
-- `String`
-- `null`
+| JavaScript | Java            |
+|------------|-----------------|
+| null       | null            |
+| undefined  | null            |
+| boolean    | Boolean         |
+| Number     | Long/Int/Double |
+| string     | String          |
+| Array      | JSArray         |
+| object     | JSObject        |
+| Function   | JSFunction      |
 
-#### Mutual conversion of JS object types
-- `JSObject` represents a JavaScript object
-- `JSFunction` represents a JavaScript function
-- `JSArray` represents a JavaScript Array
+Since JavaScript doesn't have a `long` type, additional information about `long`:
 
-#### About Long type
-There is no Long type in JavaScript, the conversion of Long type is special.
+Java --> JavaScript
+  - The Long value <= Number.MAX_SAFE_INTEGER, will be convert to Number type.
+  - The Long value > Number.MAX_SAFE_INTEGER, will be convert to BigInt type.
+  - Number.MIN_SAFE_INTEGER is the same to above.
 
-- Java --> JavaScript
-    - The Long value <= Number.MAX_SAFE_INTEGER, will be convert to Number type.
-    - The Long value > Number.MAX_SAFE_INTEGER, will be convert to BigInt type.
-    - Number.MIN_SAFE_INTEGER is the same to above.
+JavaScript --> Java
+  - Number(Int64) or BigInt --> Long type
 
-- JavaScript --> Java
-    - Number(Int64) or BigInt --> Long type
 
 ### Set Property
 Java

--- a/native/cpp/quickjs_context_jni.cpp
+++ b/native/cpp/quickjs_context_jni.cpp
@@ -271,3 +271,12 @@ Java_com_whl_quickjs_wrapper_QuickJSContext_getOwnPropertyNames(JNIEnv *env, job
     auto wrapper = reinterpret_cast<QuickJSWrapper*>(context);
     return wrapper->getOwnPropertyNames(env, thiz, obj_value);
 }
+extern "C"
+JNIEXPORT jlong JNICALL
+Java_com_whl_quickjs_wrapper_QuickJSContext_getMemoryUsedSize(JNIEnv *env, jobject thiz,
+                                                              jlong runtime) {
+    auto *rt = reinterpret_cast<JSRuntime*>(runtime);
+    JSMemoryUsage usage;
+    JS_ComputeMemoryUsage(rt, &usage);
+    return (jlong)usage.memory_used_size;
+}

--- a/native/cpp/quickjs_wrapper.cpp
+++ b/native/cpp/quickjs_wrapper.cpp
@@ -23,6 +23,13 @@ static string getJavaName(JNIEnv* env, jobject javaClass) {
     return str;
 }
 
+// quickjs 没有提供 JS_IsArrayBuffer 方法，这里通过取巧的方式来实现，后续可以替换掉
+static bool JS_IsArrayBuffer(JSValue  value) {
+    // quickjs 里的 ArrayBuffer 对应的类型枚举值
+    int8_t JS_CLASS_ARRAY_BUFFER = 19;
+    return JS_GetClassID(value) == JS_CLASS_ARRAY_BUFFER;
+}
+
 static void tryToTriggerOnError(JSContext *ctx, JSValueConst *error) {
     JSValue global = JS_GetGlobalObject(ctx);
     JSValue onerror = JS_GetPropertyStr(ctx, global, "onError");
@@ -333,6 +340,7 @@ QuickJSWrapper::QuickJSWrapper(JNIEnv *env, jobject thiz, JSRuntime *rt) {
     quickjsContextClass = (jclass)(jniEnv->NewGlobalRef(jniEnv->FindClass("com/whl/quickjs/wrapper/QuickJSContext")));
     moduleLoaderClass = (jclass)(jniEnv->NewGlobalRef(jniEnv->FindClass("com/whl/quickjs/wrapper/ModuleLoader")));
     creatorClass = (jclass)(jniEnv->NewGlobalRef(jniEnv->FindClass("com/whl/quickjs/wrapper/JSObjectCreator")));
+    byteArrayClass = (jclass) jniEnv->NewGlobalRef(env->FindClass("[B"));
 
     booleanValueOf = jniEnv->GetStaticMethodID(booleanClass, "valueOf", "(Z)Ljava/lang/Boolean;");
     integerValueOf = jniEnv->GetStaticMethodID(integerClass, "valueOf", "(I)Ljava/lang/Integer;");
@@ -376,6 +384,7 @@ QuickJSWrapper::~QuickJSWrapper() {
     jniEnv->DeleteGlobalRef(moduleLoaderClass);
     jniEnv->DeleteGlobalRef(quickjsContextClass);
     jniEnv->DeleteGlobalRef(creatorClass);
+    jniEnv->DeleteGlobalRef(byteArrayClass);
 }
 
 jobject QuickJSWrapper::toJavaObject(JNIEnv *env, jobject thiz, JSValueConst& this_obj, JSValueConst& value) const{
@@ -436,6 +445,16 @@ jobject QuickJSWrapper::toJavaObject(JNIEnv *env, jobject thiz, JSValueConst& th
                 result = env->CallObjectMethod(creatorObj, newFunctionM, thiz, value_ptr, obj_ptr);
             } else if (JS_IsArray(context, value)) {
                 result = env->CallObjectMethod(creatorObj, newArrayM, thiz, value_ptr);
+            } else if (JS_IsArrayBuffer(value)) {
+                size_t byteLength = 0;
+                uint8_t *buffer = JS_GetArrayBuffer(context, &byteLength, value);
+                jbyteArray byteArray = env->NewByteArray(byteLength);
+                void *elementsPtr = env->GetPrimitiveArrayCritical(byteArray, nullptr);
+                jbyte *elements = reinterpret_cast<jbyte *>(elementsPtr);
+                memcpy(elements, buffer, byteLength);
+                result = byteArray;
+                JS_FreeValue(context, value);
+                env->ReleasePrimitiveArrayCritical(byteArray, elements, 0);
             } else {
                 result = env->CallObjectMethod(creatorObj, newObjectM, thiz, value_ptr);
             }
@@ -514,7 +533,8 @@ jobject QuickJSWrapper::call(JNIEnv *env, jobject thiz, jlong func, jlong this_o
         // 基础类型(例如 string )和 Java callback 类型需要使用完 free.
         if (env->IsInstanceOf(arg, stringClass) || env->IsInstanceOf(arg, doubleClass) ||
             env->IsInstanceOf(arg, integerClass) || env->IsInstanceOf(arg, longClass) ||
-            env->IsInstanceOf(arg, booleanClass) || env->IsInstanceOf(arg, jsCallFunctionClass)) {
+            env->IsInstanceOf(arg, booleanClass) || env->IsInstanceOf(arg, jsCallFunctionClass)
+            || env->IsInstanceOf(arg, byteArrayClass)) {
             freeArguments.push_back(jsArg);
         }
 
@@ -676,6 +696,12 @@ JSValue QuickJSWrapper::toJSValue(JNIEnv *env, jobject thiz, jobject value) cons
         }
     } else if (env->IsInstanceOf(value, booleanClass)) {
         result = JS_NewBool(context, env->CallBooleanMethod(value, booleanGetValue));
+    } else if (env->IsInstanceOf(value, byteArrayClass)) {
+        jbyteArray bytes = static_cast<jbyteArray>(value);
+        jbyte* byteData = env->GetByteArrayElements(bytes, nullptr);
+        jsize length = env->GetArrayLength(bytes);
+        result = JS_NewArrayBufferCopy(context, reinterpret_cast<uint8_t*>(byteData), length);
+        env->ReleaseByteArrayElements(bytes, byteData, JNI_ABORT);
     } else if (env->IsInstanceOf(value, jsObjectClass)) {
         result = JS_MKPTR(JS_TAG_OBJECT, reinterpret_cast<void *>(env->CallLongMethod(value, jsObjectGetValue)));
     } else if (env->IsInstanceOf(value, jsCallFunctionClass)) {

--- a/native/cpp/quickjs_wrapper.cpp
+++ b/native/cpp/quickjs_wrapper.cpp
@@ -238,6 +238,12 @@ jsModuleLoaderFunc(JSContext *ctx, const char *module_name, void *opaque) {
         int scriptLen = env->GetStringUTFLength((jstring) result);
         JSValue func_val = JS_Eval(ctx, script, scriptLen, module_name,
                                    JS_EVAL_TYPE_MODULE | JS_EVAL_FLAG_COMPILE_ONLY);
+        if (JS_IsException(func_val)) {
+            JS_FreeValue(ctx, func_val);
+            throwJSException(env, ctx);
+            return (JSModuleDef *) JS_VALUE_GET_PTR(JS_EXCEPTION);
+        }
+
         m = JS_VALUE_GET_PTR(func_val);
         JS_FreeValue(ctx, func_val);
     }

--- a/native/cpp/quickjs_wrapper.h
+++ b/native/cpp/quickjs_wrapper.h
@@ -42,6 +42,7 @@ public:
     jclass quickjsContextClass;
     jclass moduleLoaderClass;
     jclass creatorClass;
+    jclass byteArrayClass;
     JSValue ownPropertyNames;
 
     jmethodID booleanValueOf;

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1240,7 +1240,7 @@ public class QuickJSTest {
     public void testArrayBytes() {
         QuickJSContext context = createContext();
         byte[] bytes = "test测试".getBytes();
-        byte[] buffer = (byte[]) context.evaluate("new Uint8Array([116, 101, 115, 116, 230, 181, 139, 232, 175, 149]).buffer");
+        byte[] buffer = (byte[]) context.evaluate("new Int8Array([116, 101, 115, 116, -26, -75, -117, -24, -81, -107]).buffer");
         assertArrayEquals(bytes, buffer);
 
         context.getGlobalObject().setProperty("testBuffer", bytes);
@@ -1253,7 +1253,7 @@ public class QuickJSTest {
     @Test
     public void testArrayBytes1() {
         QuickJSContext context = createContext();
-        JSFunction bufferTest = (JSFunction) context.evaluate("const bufferTest = (buffer) => { if(new Uint8Array(buffer)[0] !== 116) { throw Error('failed, not equal'); }; }; bufferTest;");
+        JSFunction bufferTest = (JSFunction) context.evaluate("const bufferTest = (buffer) => { if(new Int8Array(buffer)[0] !== 116) { throw Error('failed, not equal'); }; }; bufferTest;");
         bufferTest.callVoid("test测试".getBytes());
         context.destroy();
     }

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1236,4 +1236,21 @@ public class QuickJSTest {
         context.destroy();
     }
 
+    @Test
+    public void testArrayBytes() {
+        QuickJSContext context = createContext();
+        byte[] bytes = "test测试".getBytes();
+        byte[] buffer = (byte[]) context.evaluate("new Uint8Array([116, 101, 115, 116, 230, 181, 139, 232, 175, 149]).buffer");
+        assertArrayEquals(bytes, buffer);
+        context.destroy();
+    }
+
+    @Test
+    public void testArrayBytes1() {
+        QuickJSContext context = createContext();
+        JSFunction bufferTest = (JSFunction) context.evaluate("const bufferTest = (buffer) => { console.log(new Uint8Array(buffer)); }; bufferTest;");
+        bufferTest.callVoid("test测试".getBytes());
+        context.destroy();
+    }
+
 }

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1242,13 +1242,18 @@ public class QuickJSTest {
         byte[] bytes = "test测试".getBytes();
         byte[] buffer = (byte[]) context.evaluate("new Uint8Array([116, 101, 115, 116, 230, 181, 139, 232, 175, 149]).buffer");
         assertArrayEquals(bytes, buffer);
+
+        context.getGlobalObject().setProperty("testBuffer", bytes);
+        byte[] testBuffers = context.getGlobalObject().getBytes("testBuffer");
+        assertArrayEquals(testBuffers, buffer);
+
         context.destroy();
     }
 
     @Test
     public void testArrayBytes1() {
         QuickJSContext context = createContext();
-        JSFunction bufferTest = (JSFunction) context.evaluate("const bufferTest = (buffer) => { console.log(new Uint8Array(buffer)); }; bufferTest;");
+        JSFunction bufferTest = (JSFunction) context.evaluate("const bufferTest = (buffer) => { if(new Uint8Array(buffer)[0] !== 116) { throw Error('failed, not equal'); }; }; bufferTest;");
         bufferTest.callVoid("test测试".getBytes());
         context.destroy();
     }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
@@ -14,6 +14,7 @@ public interface JSObject {
     void setProperty(String name, JSObject value);
     void setProperty(String name, boolean value);
     void setProperty(String name, double value);
+    void setProperty(String name, byte[] value);
     void setProperty(String name, JSCallFunction value);
     void setProperty(String name, Class<?> clazz);
     long getPointer();
@@ -32,6 +33,7 @@ public interface JSObject {
     Double getDoubleProperty(String name);
     Double getDouble(String name);
     Long getLong(String name);
+    byte[] getBytes(String name);
     @Deprecated
     JSObject getJSObjectProperty(String name);
     JSObject getJSObject(String name);

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
@@ -125,6 +125,11 @@ public class QuickJSContext implements Closeable {
         setMemoryLimit(runtime, memoryLimitSize);
     }
 
+    // Return the byte size.
+    public long getMemoryUsedSize() {
+        return getMemoryUsedSize(runtime);
+    }
+
     public void dumpMemoryUsage(File target) {
         if (target == null || !target.exists()) {
             return;
@@ -578,6 +583,7 @@ public class QuickJSContext implements Closeable {
     private native void setMemoryLimit(long runtime, int size);
     private native void dumpMemoryUsage(long runtime, String fileName);
     private native void dumpObjects(long runtime, String fileName);
+    private native long getMemoryUsedSize(long runtime);
 
     // context
     private native long createContext(long runtime);

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSObject.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSObject.java
@@ -85,6 +85,11 @@ public class QuickJSObject implements JSObject {
     }
 
     @Override
+    public void setProperty(String name, byte[] value) {
+        setPropertyObject(name, value);
+    }
+
+    @Override
     public void setProperty(String name, JSCallFunction value) {
         setPropertyObject(name, value);
     }
@@ -174,6 +179,12 @@ public class QuickJSObject implements JSObject {
     public Long getLong(String name) {
         Object value = getProperty(name);
         return value instanceof Long ? (Long) value : null;
+    }
+
+    @Override
+    public byte[] getBytes(String name) {
+        Object value = getProperty(name);
+        return value instanceof byte[] ? (byte[]) value : null;
     }
 
     @Override


### PR DESCRIPTION
## Summary by Sourcery

在 QuickJS 中添加对 ArrayBuffer 和 byte[] 类型之间转换的支持，包括必要的 JNI 和 Java 方法实现。更新文档并添加测试以验证新功能。

新功能：
- 在 QuickJS 中添加对 ArrayBuffer 和 byte[] 类型之间转换的支持。

增强：
- 由于缺少本机方法，实现一种检测 QuickJS 中 ArrayBuffer 类型的变通方法。

文档：
- 更新 README 以记录对 byte[] 和 ArrayBuffer 转换的新支持。

测试：
- 添加测试以验证 byte[] 和 ArrayBuffer 之间的转换，确保功能正确。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for converting between ArrayBuffer and byte[] types in QuickJS, including necessary JNI and Java method implementations. Update documentation and add tests to verify the new functionality.

New Features:
- Add support for conversion between ArrayBuffer and byte[] types in QuickJS.

Enhancements:
- Implement a workaround for detecting ArrayBuffer types in QuickJS due to the absence of a native method.

Documentation:
- Update README to document the new support for byte[] and ArrayBuffer conversion.

Tests:
- Add tests to verify the conversion between byte[] and ArrayBuffer, ensuring correct functionality.

</details>