### PR TITLE
Feature/20241203

### DIFF
--- a/native/cpp/quickjs_context_jni.cpp
+++ b/native/cpp/quickjs_context_jni.cpp
@@ -52,9 +52,9 @@ Java_com_whl_quickjs_wrapper_QuickJSContext_getProperty(JNIEnv *env, jobject thi
 extern "C"
 JNIEXPORT jobject JNICALL
 Java_com_whl_quickjs_wrapper_QuickJSContext_call(JNIEnv *env, jobject thiz, jlong context,
-                                                 jlong func, jlong this_obj, jobjectArray args) {
+                                                 jlong func, jlong this_obj, jint this_obj_tag, jobjectArray args) {
     auto wrapper = reinterpret_cast<QuickJSWrapper*>(context);
-    return wrapper->call(env, thiz, func, this_obj, args);
+    return wrapper->call(env, thiz, func, this_obj, this_obj_tag, args);
 }
 
 extern "C"

--- a/native/cpp/quickjs_wrapper.cpp
+++ b/native/cpp/quickjs_wrapper.cpp
@@ -393,7 +393,7 @@ QuickJSWrapper::~QuickJSWrapper() {
     jniEnv->DeleteGlobalRef(byteArrayClass);
 }
 
-jobject QuickJSWrapper::toJavaObject(JNIEnv *env, jobject thiz, JSValueConst& this_obj, JSValueConst& value) const{
+jobject QuickJSWrapper::toJavaObject(JNIEnv *env, jobject thiz, JSValueConst this_obj, JSValueConst value) const{
     jobject result;
     switch (JS_VALUE_GET_NORM_TAG(value)) {
         case JS_TAG_EXCEPTION: {
@@ -493,11 +493,7 @@ jobject QuickJSWrapper::evaluate(JNIEnv *env, jobject thiz, jstring script, jstr
         return nullptr;
     }
 
-    JSValue global = JS_GetGlobalObject(context);
-    jobject jsObj = toJavaObject(env, thiz, global, result);
-    JS_FreeValue(context, global);
-
-    return jsObj;
+    return toJavaObject(env, thiz, JS_UNDEFINED, result);
 }
 
 jobject QuickJSWrapper::getGlobalObject(JNIEnv *env, jobject thiz) const {
@@ -829,7 +825,7 @@ jobject QuickJSWrapper::execute(JNIEnv *env, jobject thiz, jbyteArray bytecode) 
 
     jobject result;
     if (!JS_IsException(val)) {
-        result = toJavaObject(env, thiz, obj, val);
+        result = toJavaObject(env, thiz, JS_UNDEFINED, val);
     } else {
         result = nullptr;
         throwJSException(env, context);
@@ -876,8 +872,7 @@ jobject QuickJSWrapper::getOwnPropertyNames(JNIEnv *env, jobject thiz, jlong obj
         return nullptr;
     }
 
-    JSValue nullValue = JS_NULL;
-    return toJavaObject(env, thiz, nullValue, ret);
+    return toJavaObject(env, thiz, JS_UNDEFINED, ret);
 }
 
 jstring QuickJSWrapper::toJavaString(JNIEnv *env, JSValue value) const {

--- a/native/cpp/quickjs_wrapper.cpp
+++ b/native/cpp/quickjs_wrapper.cpp
@@ -368,7 +368,7 @@ QuickJSWrapper::QuickJSWrapper(JNIEnv *env, jobject thiz, JSRuntime *rt) {
     newArrayM = jniEnv->GetMethodID(creatorClass, "newArray",
                                     "(Lcom/whl/quickjs/wrapper/QuickJSContext;J)Lcom/whl/quickjs/wrapper/JSArray;");
     newFunctionM = jniEnv->GetMethodID(creatorClass, "newFunction",
-                                       "(Lcom/whl/quickjs/wrapper/QuickJSContext;JJ)Lcom/whl/quickjs/wrapper/JSFunction;");
+                                       "(Lcom/whl/quickjs/wrapper/QuickJSContext;JJI)Lcom/whl/quickjs/wrapper/JSFunction;");
 }
 
 QuickJSWrapper::~QuickJSWrapper() {
@@ -448,7 +448,7 @@ jobject QuickJSWrapper::toJavaObject(JNIEnv *env, jobject thiz, JSValueConst thi
             jobject creatorObj = env->CallObjectMethod(thiz, creatorM);
             if (JS_IsFunction(context, value)) {
                 auto obj_ptr = reinterpret_cast<jlong>(JS_VALUE_GET_PTR(this_obj));
-                result = env->CallObjectMethod(creatorObj, newFunctionM, thiz, value_ptr, obj_ptr);
+                result = env->CallObjectMethod(creatorObj, newFunctionM, thiz, value_ptr, obj_ptr, JS_VALUE_GET_TAG(this_obj));
             } else if (JS_IsArray(context, value)) {
                 result = env->CallObjectMethod(creatorObj, newArrayM, thiz, value_ptr);
             } else if (JS_IsArrayBuffer(value)) {
@@ -521,7 +521,7 @@ jobject QuickJSWrapper::getProperty(JNIEnv *env, jobject thiz, jlong value, jstr
 }
 
 jobject QuickJSWrapper::call(JNIEnv *env, jobject thiz, jlong func, jlong this_obj,
-                             jobjectArray args) {
+                             jint this_obj_tag, jobjectArray args) {
     int argc = env->GetArrayLength(args);
     vector<JSValue> arguments;
     vector<JSValue> freeArguments;
@@ -545,13 +545,7 @@ jobject QuickJSWrapper::call(JNIEnv *env, jobject thiz, jlong func, jlong this_o
         arguments.push_back(jsArg);
     }
 
-    JSValue jsObj;
-    if (this_obj == 0) {
-        jsObj = JS_UNDEFINED;
-    } else {
-        jsObj = JS_MKPTR(JS_TAG_OBJECT, reinterpret_cast<void *>(this_obj));
-    }
-
+    JSValue jsObj = JS_MKPTR(this_obj_tag, reinterpret_cast<void *>(this_obj));
     JSValue jsFunc = JS_MKPTR(JS_TAG_OBJECT, reinterpret_cast<void *>(func));
 
     JSValue ret = JS_Call(context, jsFunc, jsObj, arguments.size(), arguments.data());

--- a/native/cpp/quickjs_wrapper.h
+++ b/native/cpp/quickjs_wrapper.h
@@ -71,7 +71,7 @@ public:
     jobject getGlobalObject(JNIEnv*, jobject thiz) const;
     jobject getProperty(JNIEnv*, jobject thiz, jlong value, jstring name);
     void setProperty(JNIEnv*, jobject thiz, jlong this_obj, jstring name, jobject value) const;
-    jobject call(JNIEnv *env, jobject thiz, jlong func, jlong this_obj, jobjectArray args);
+    jobject call(JNIEnv *env, jobject thiz, jlong func, jlong this_obj, jint this_obj_tag, jobjectArray args);
     jstring jsonStringify(JNIEnv *env, jlong value) const;
     jint length(JNIEnv *env, jlong value) const;
     jobject get(JNIEnv *env, jobject thiz, jlong value, jint index);

--- a/native/cpp/quickjs_wrapper.h
+++ b/native/cpp/quickjs_wrapper.h
@@ -18,7 +18,7 @@ using namespace std;
 class QuickJSWrapper {
 private:
     jstring toJavaString(JNIEnv *env, JSValue value) const;
-    jobject toJavaObject(JNIEnv *env, jobject thiz, JSValueConst& this_obj, JSValueConst& value) const;
+    jobject toJavaObject(JNIEnv *env, jobject thiz, JSValueConst this_obj, JSValueConst value) const;
     JSValue toJSValue(JNIEnv *env, jobject thiz, jobject value) const;
 
 public:

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1263,4 +1263,20 @@ public class QuickJSTest {
         context.destroy();
     }
 
+    @Test
+    public void testAsyncSourceFunc() {
+        QuickJSContext context = createContext();
+        byte[] compile = context.compile("async function testUpdate() {\n" +
+                "\tconsole.log(123);\n" +
+                "}\n" +
+                "testUpdate;");
+        Object evaluate = context.execute(compile);
+        if (evaluate instanceof JSFunction) {
+            System.out.println("string: " + evaluate);
+            ((JSFunction) evaluate).callVoid();
+        }
+
+        context.destroy();
+    }
+
 }

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1205,8 +1205,6 @@ public class QuickJSTest {
         assertEquals("[{a={c=xxx}}, 2, qqq, 1.22]", array.toArray().toString());
         array.release();
 
-        assertEquals("{console={}, a={a=123, b=[1, 2]}, b=[{a={c=xxx}}, 2, qqq, 1.22], Infinity=-9223372036854775808, Reflect={}, NaN=NaN, JSON={}, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, Atomics={}, undefined=null}", context.getGlobalObject().toMap().toString());
-
         JSObject emptyObj = (JSObject) context.evaluate("var a = { emptyArray: [] };a;");
         assertEquals("{emptyArray=[]}", emptyObj.toMap().toString());
         emptyObj.release();
@@ -1217,12 +1215,8 @@ public class QuickJSTest {
     @Test
     public void testObjectToMapFilter() {
         QuickJSContext context = createContext();
-        HashMap<String, Object> map = context.getGlobalObject().toMap((key, pointer, extra) -> {
-            assertEquals("test", extra.toString());
-            return key.equals("Infinity");
-        }, "test");
-        System.out.println(map.toString());
-        assertEquals("{console={}, Reflect={}, NaN=NaN, JSON={}, Math={LN2=0.6931471805599453, LN10=2.302585092994046, LOG2E=1.4426950408889634, E=2.718281828459045, SQRT2=1.4142135623730951, LOG10E=0.4342944819032518, PI=3.141592653589793, SQRT1_2=0.7071067811865476}, Atomics={}, undefined=null}", map.toString());
+        HashMap<String, Object> map = context.getGlobalObject().toMap((key, pointer, extra) -> key.equals("Math") || key.equals("Infinity"));
+        assertEquals("{console={}, Reflect={}, NaN=NaN, JSON={}, Atomics={}, undefined=null}", map.toString());
         context.destroy();
     }
 

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObjectCreator.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObjectCreator.java
@@ -6,5 +6,5 @@ package com.whl.quickjs.wrapper;
 public interface JSObjectCreator {
     JSObject newObject(QuickJSContext context, long pointer);
     JSArray newArray(QuickJSContext context, long pointer);
-    JSFunction newFunction(QuickJSContext context, long pointer, long thisPointer);
+    JSFunction newFunction(QuickJSContext context, long pointer, long thisPointer, int thisPointerTag);
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
@@ -66,8 +66,8 @@ public class QuickJSContext implements Closeable {
             }
 
             @Override
-            public JSFunction newFunction(QuickJSContext context, long pointer, long thisPointer) {
-                return new QuickJSFunction(context, pointer, thisPointer);
+            public JSFunction newFunction(QuickJSContext context, long pointer, long thisPointer, int thisPointerTag) {
+                return new QuickJSFunction(context, pointer, thisPointer, thisPointerTag);
             }
         });
     }
@@ -198,8 +198,8 @@ public class QuickJSContext implements Closeable {
                 }
 
                 @Override
-                public JSFunction newFunction(QuickJSContext c, long pointer, long thisPointer) {
-                    JSFunction o = creator.newFunction(c, pointer, thisPointer);
+                public JSFunction newFunction(QuickJSContext c, long pointer, long thisPointer, int thisPointerTag) {
+                    JSFunction o = creator.newFunction(c, pointer, thisPointer, thisPointerTag);
                     if (enableStackTrace) {
                         o.setStackTrace(new Throwable());
                     }
@@ -458,7 +458,7 @@ public class QuickJSContext implements Closeable {
         set(context, jsArray.getPointer(), value, index);
     }
 
-    Object call(JSObject func, long objPointer, Object... args) {
+    Object call(JSObject func, long objPointer, int thisPointerTag, Object... args) {
         checkSameThread();
         checkDestroyed();
 
@@ -469,7 +469,7 @@ public class QuickJSContext implements Closeable {
             }
         }
 
-        return call(context, func.getPointer(), objPointer, args);
+        return call(context, func.getPointer(), objPointer, thisPointerTag, args);
     }
 
     /**
@@ -594,7 +594,7 @@ public class QuickJSContext implements Closeable {
     private native Object evaluate(long context, String script, String fileName);
     private native Object evaluateModule(long context, String script, String fileName);
     private native JSObject getGlobalObject(long context);
-    private native Object call(long context, long func, long thisObj, Object[] args);
+    private native Object call(long context, long func, long thisObj, int thisObjTag, Object[] args);
     private native Object getProperty(long context, long objValue, String name);
     private native void setProperty(long context, long objValue, String name, Object value);
     private native String stringify(long context, long objValue);

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSFunction.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSFunction.java
@@ -20,10 +20,12 @@ public class QuickJSFunction extends QuickJSObject implements JSFunction {
     private Status currentStatus = Status.NOT_CALLED;
 
     private final long thisPointer;
+    private final int thisPointerTag;
 
-    public QuickJSFunction(QuickJSContext context, long pointer, long thisPointer) {
+    public QuickJSFunction(QuickJSContext context, long pointer, long thisPointer, int thisPointerTag) {
         super(context, pointer);
         this.thisPointer = thisPointer;
+        this.thisPointerTag = thisPointerTag;
     }
 
     @Override
@@ -42,7 +44,7 @@ public class QuickJSFunction extends QuickJSObject implements JSFunction {
         checkRefCountIsZero();
 
         currentStatus = Status.CALLING;
-        Object ret = getContext().call(this, thisPointer, args);
+        Object ret = getContext().call(this, thisPointer, thisPointerTag, args);
         currentStatus = Status.CALLED;
 
         if (stashTimes > 0) {


### PR DESCRIPTION
## Sourcery的总结

增强QuickJSWrapper以支持函数调用中的'thisPointerTag'，改善JavaScript函数的处理。重构相关类以适应此更改，并为异步函数执行添加测试。

新功能：
- 引入对函数调用中'thisPointerTag'的支持，允许更精确地控制JavaScript函数的执行。

增强：
- 重构QuickJSWrapper和相关类以使用'thisPointerTag'，以更好地处理JavaScript函数调用。

测试：
- 添加新的测试用例'testAsyncSourceFunc'以验证异步JavaScript函数的执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the QuickJSWrapper to support 'thisPointerTag' in function calls, improving the handling of JavaScript functions. Refactor related classes to accommodate this change and add a test for asynchronous function execution.

New Features:
- Introduce support for handling 'thisPointerTag' in function calls, allowing more precise control over JavaScript function execution.

Enhancements:
- Refactor the QuickJSWrapper and related classes to use 'thisPointerTag' for better handling of JavaScript function calls.

Tests:
- Add a new test case 'testAsyncSourceFunc' to verify the execution of asynchronous JavaScript functions.

</details>