### PR TITLE
Feature/2.4.3

### DIFF
--- a/native/cpp/quickjs_context_jni.cpp
+++ b/native/cpp/quickjs_context_jni.cpp
@@ -280,3 +280,14 @@ Java_com_whl_quickjs_wrapper_QuickJSContext_getMemoryUsedSize(JNIEnv *env, jobje
     JS_ComputeMemoryUsage(rt, &usage);
     return (jlong)usage.memory_used_size;
 }
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_whl_quickjs_wrapper_QuickJSContext_setGCThreshold(JNIEnv *env, jobject thiz, jlong runtime,
+                                                           jint size) {
+    auto *rt = reinterpret_cast<JSRuntime*>(runtime);
+    // use -1 to disable automatic GC
+    if (size < 0) {
+        size = -1;
+    }
+    JS_SetGCThreshold(rt, size);
+}

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -1017,11 +1017,11 @@ public class QuickJSTest {
             JSObject jsObject = jsContext.createNewJSObject();
             JSCallFunction function = args -> null;
             jsObject.setProperty("test", function);
-            // jsObject.release();
+            jsObject.release();
         }
 
         // QuickJSLoader.initConsoleLog 方法里有调用过一次 setProperty，总数还剩1个
-        // assertEquals(1, jsContext.getCallFunctionMapSize());
+        assertEquals(1, jsContext.getCallFunctionMapSize());
         jsContext.releaseObjectRecords();
         jsContext.releaseObjectRecords();
         jsContext.destroy();

--- a/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
+++ b/wrapper-android/src/androidTest/java/com/whl/quickjs/wrapper/QuickJSTest.java
@@ -24,7 +24,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -1210,6 +1212,27 @@ public class QuickJSTest {
         try (QuickJSContext context = createContext()) {
             HashMap<String, Object> map = context.getGlobalObject().toMap((key, pointer, extra) -> key.equals("Math") || key.equals("Infinity"));
             assertEquals("{console={}, Reflect={}, NaN=NaN, JSON={}, Atomics={}, undefined=null}", map.toString());
+        }
+    }
+
+    @Test
+    public void testObjectToCustomMap() {
+        try (QuickJSContext context = createContext()) {
+            StringBuilder expected = new StringBuilder("{");
+            JSObject object = context.createNewJSObject();
+            for (int i = 0; i < 100; i++) {
+                object.setProperty(Integer.toString(i), i);
+                expected.append(i).append("=").append(i);
+                if (i != 99) {
+                    expected.append(", ");
+                }
+            }
+            expected.append("}");
+            Map<String, Object> linkedMap = object.toMap(null, null, LinkedHashMap::new);
+            HashMap<String, Object> hashMap = object.toMap();
+            assertEquals(expected.toString(), linkedMap.toString());
+            assertNotEquals(expected.toString(), hashMap.toString());
+            object.release();
         }
     }
 

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/JSObject.java
@@ -2,6 +2,7 @@ package com.whl.quickjs.wrapper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 public interface JSObject {
 
@@ -63,6 +64,6 @@ public interface JSObject {
 
     HashMap<String, Object> toMap(MapFilter filter);
     ArrayList<Object> toArray(MapFilter filter);
-    HashMap<String, Object> toMap(MapFilter filter, Object extra);
-    ArrayList<Object> toArray(MapFilter filter, Object extra);
+    Map<String, Object> toMap(MapFilter filter, Object extra, MapCreator mapCreator);
+    ArrayList<Object> toArray(MapFilter filter, Object extra, MapCreator mapCreator);
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapCreator.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/MapCreator.java
@@ -1,0 +1,10 @@
+package com.whl.quickjs.wrapper;
+
+import java.util.Map;
+
+/**
+ * Created by Harlon Wang on 2025/1/21.
+ */
+public interface MapCreator {
+    Map<String, Object> get();
+}

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSArray.java
@@ -3,6 +3,7 @@ package com.whl.quickjs.wrapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 /**
  * Created by Harlon Wang on 2024/2/13.
@@ -38,7 +39,7 @@ public class QuickJSArray extends QuickJSObject implements JSArray {
 
     @Override
     public HashMap<String, Object> toMap(MapFilter filter) {
-        return toMap(filter, null);
+        return (HashMap<String, Object>) toMap(filter, null, null);
     }
 
     @Override
@@ -48,20 +49,20 @@ public class QuickJSArray extends QuickJSObject implements JSArray {
 
     @Override
     public ArrayList<Object> toArray(MapFilter filter) {
-        return toArray(filter, null);
+        return toArray(filter, null, HashMap::new);
     }
 
     @Override
-    public ArrayList<Object> toArray(MapFilter filter, Object extra) {
+    public ArrayList<Object> toArray(MapFilter filter, Object extra, MapCreator creator) {
         ArrayList<Object> arrayList = new ArrayList<>(length());
         HashSet<Long> circulars = new HashSet<>();
-        convertToMap(this, arrayList, circulars, filter, extra);
+        convertToMap(this, arrayList, circulars, filter, extra, creator);
         circulars.clear();
         return arrayList;
     }
 
     @Override
-    public HashMap<String, Object> toMap(MapFilter filter, Object extra) {
+    public Map<String, Object> toMap(MapFilter filter, Object extra, MapCreator mapCreator) {
         throw new UnsupportedOperationException("Array types are not yet supported for conversion to map. You should use toArray.");
     }
 }

--- a/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
+++ b/wrapper-java/src/main/java/com/whl/quickjs/wrapper/QuickJSContext.java
@@ -117,6 +117,10 @@ public class QuickJSContext implements Closeable {
         setMaxStackSize(runtime, maxStackSize);
     }
 
+    public void setGCThreshold(int thresholdSize) {
+        setGCThreshold(runtime, thresholdSize);
+    }
+
     public void runGC() {
         runGC(runtime);
     }
@@ -588,6 +592,7 @@ public class QuickJSContext implements Closeable {
     private native void dumpMemoryUsage(long runtime, String fileName);
     private native void dumpObjects(long runtime, String fileName);
     private native long getMemoryUsedSize(long runtime);
+    private native void setGCThreshold(long runtime, int size);
 
     // context
     private native long createContext(long runtime);


### PR DESCRIPTION
## 摘要（由 Sourcery 提供）

允许在将 JSObjects 转换为 Java Maps 时创建自定义映射实例，并在 QuickJSContext 中添加 setGCThreshold 方法。

新特性：
- 添加了在将 JSObjects 转换为 Java Maps 时支持自定义映射创建。
- 在 `QuickJSContext` 类中添加了 `setGCThreshold` 方法，用于控制垃圾回收阈值。

测试：
- 为 JSObjects 自定义映射创建添加了测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow creating custom map instances when converting JSObjects to Java Maps and add a setGCThreshold method to QuickJSContext.

New Features:
- Added support for custom map creation when converting JSObjects to Java Maps.
- Added a `setGCThreshold` method to the `QuickJSContext` class to control the garbage collection threshold.

Tests:
- Added tests for custom map creation when converting JSObjects.

</details>