### PR TITLE
Feature/16kb support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 3.2.0 *(2025-05-15)*
+- feature: support 16 KB page sizes.
+
 ## 3.1.0 *(2025-03-17)*
 - Align internal and external version numbers to 3.1.0, no functional changes – codebase remains identical to 2.4.5.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 
 android {
     namespace 'com.whl.quickjs.wrapper.sample'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "com.whl.quickjs.wrapper.sample"
         minSdkVersion 21
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 

--- a/wrapper-android/build.gradle
+++ b/wrapper-android/build.gradle
@@ -4,11 +4,11 @@ plugins {
 
 android {
     namespace 'com.whl.quickjs.android'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdkVersion 21
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 

--- a/wrapper-android/src/main/CMakeLists.txt
+++ b/wrapper-android/src/main/CMakeLists.txt
@@ -41,7 +41,7 @@ find_library( # Sets the name of the path variable.
 
 target_link_libraries( # Specifies the target library.
         quickjs-android-wrapper
-
+        "-Wl,-z,max-page-size=16384"
         # Links the target library to the log library
         # included in the NDK.
-        ${log-lib} )
+        ${log-lib})


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

引入 16 KB 页面大小支持，通过更新 CMake 构建，并将 Android SDK 目标版本提升至 API 35，并记录 3.2.0 版本发布。

新特性：
- 通过链接器标志在 QuickJS Android 封装器中启用 16 KB 页面大小支持

增强：
- 将 Android compileSdk 和 targetSdk 版本升级到 API 35

文档：
- 在 CHANGELOG 中添加 3.2.0 版本条目，以记录 16 KB 页面大小支持

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce 16 KB page size support by updating the CMake build, bump Android SDK targets to API 35, and document the 3.2.0 release.

New Features:
- Enable 16 KB page size support in the QuickJS Android wrapper via linker flag

Enhancements:
- Upgrade Android compileSdk and targetSdk versions to API 35

Documentation:
- Add 3.2.0 release entry for 16 KB page size support in CHANGELOG

</details>