### PR TITLE
Add build scritps for Windows, macOs and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,24 +71,16 @@ Alternatively, if you already have the project checked out, you can initialize t
 ```git
 git submodule update --init
 ```
-To build the JNI shared library, please follow these steps: 
-- Install [jdk](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html) and [cmake](https://cmake.org/download/).  
-- Set the **JAVA_HOME** system environment variable, and add **cmake** to your **PATH**.
-For Windows users, you should install [mingw-w64](https://github.com/skeeto/w64devkit) and add **bin** directory to **PATH**.  
-- For Windows
-```bash
-cd wrapper-java\src\main
-cmake -B build -S .  -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-```
+To build the JNI shared library, please follow these steps:
 
-- For Linux and macOS
-```shell
-cd wrapper-java/src/main
-cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-```
+1. Install [JDK](https://docs.aws.amazon.com/corretto/latest/corretto-7-ug/downloads-list.html) and [CMake](https://cmake.org/download/).
 
+2. Set the **JAVA_HOME** system environment variable, and add **CMake** to your **PATH**.  
+    - For Windows users, install [mingw-w64](https://github.com/skeeto/w64devkit) and add its **bin** directory to your **PATH**.
+
+3. Run the build script:  
+    - **Windows:** [build-jni.bat](./build-jni.bat)
+    - **MacOS/Linux:** [build-jni.sh](./build-jni.sh)
 ## Usage
 
 ### Initialization

--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ Alternatively, if you already have the project checked out, you can initialize t
 ```git
 git submodule update --init
 ```
+To build the JNI shared library, please follow these steps: 
+- Install [jdk](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html) and [cmake](https://cmake.org/download/).  
+- Set the **JAVA_HOME** system environment variable, and add **cmake** to your **PATH**.
+For Windows users, you should install [mingw-w64](https://github.com/skeeto/w64devkit), which provides **gcc** for the Windows platform.  
+Remember to add **gcc** to **PATH**.  
+- For Windows
+```bash
+cd wrapper-java\src\main
+cmake -B build -S .  -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
+
+- For Linux and macOS
+```shell
+cd wrapper-java\src\main
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ git submodule update --init
 To build the JNI shared library, please follow these steps: 
 - Install [jdk](https://docs.aws.amazon.com/corretto/latest/corretto-17-ug/downloads-list.html) and [cmake](https://cmake.org/download/).  
 - Set the **JAVA_HOME** system environment variable, and add **cmake** to your **PATH**.
-For Windows users, you should install [mingw-w64](https://github.com/skeeto/w64devkit), which provides **gcc** for the Windows platform.  
-Remember to add **gcc** to **PATH**.  
+For Windows users, you should install [mingw-w64](https://github.com/skeeto/w64devkit) and add **bin** directory to **PATH**.  
 - For Windows
 ```bash
 cd wrapper-java\src\main
@@ -85,7 +84,7 @@ cmake --build build
 
 - For Linux and macOS
 ```shell
-cd wrapper-java\src\main
+cd wrapper-java/src/main
 cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 ```

--- a/build-jni.bat
+++ b/build-jni.bat
@@ -1,0 +1,11 @@
+@echo off
+cd wrapper-java\src\main
+if exist build (
+    echo Deleting old build folder...
+    rmdir /s /q build
+)
+cmake -B build -S . -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+COPY build\libquickjs-java-wrapper.dll ..\..\..
+echo Build success
+pause

--- a/build-jni.bat
+++ b/build-jni.bat
@@ -1,11 +1,32 @@
 @echo off
+setlocal
+
 cd wrapper-java\src\main
+
+set args=
+set build_args=
+
+where ninja >nul 2>nul
+if errorlevel 1 (
+    set args=%args% -G "MinGW Makefiles"
+) else (
+    set args=%args% -G Ninja -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+    set build_args=%build_args% -j %NUMBER_OF_PROCESSORS%
+)
+
 if exist build (
     echo Deleting old build folder...
     rmdir /s /q build
 )
-cmake -B build -S . -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release
-cmake --build build
-COPY build\libquickjs-java-wrapper.dll ..\..\..
+
+call :run cmake -B build -S . %args% -DCMAKE_BUILD_TYPE=Release || exit /b 1
+call :run cmake --build build %build_args% || exit /b 1
+call :run copy build\libquickjs-java-wrapper.dll ..\..\.. || exit /b 1
+
 echo Build success
-pause
+exit /b
+
+:run
+echo ^> %*
+%*
+exit /b %errorlevel%

--- a/build-jni.sh
+++ b/build-jni.sh
@@ -1,17 +1,37 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+run() {
+    echo "> $*"
+    "$@"
+}
+
 cd wrapper-java/src/main
+
 if [ -d build ]; then
     echo "Deleting old build folder..."
     rm -rf build
 fi
-cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
-cmake --build build
+
+if command -v ninja >/dev/null 2>&1; then
+    GENERATOR_ARGS="-G Ninja"
+    BUILD_ARGS="-j $(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+else
+    GENERATOR_ARGS=""
+    BUILD_ARGS=""
+fi
+
+run cmake -B build -S . $GENERATOR_ARGS -DCMAKE_BUILD_TYPE=Release
+run cmake --build build $BUILD_ARGS
+
 OS_NAME=$(uname)
 if [[ "$OS_NAME" == "Darwin" ]]; then
-    DYLIB_EXT="dylib"   # macOS
+    DYLIB_EXT="dylib"
 else
-    DYLIB_EXT="so"      # Linux
+    DYLIB_EXT="so"
 fi
-cp build/libquickjs-java-wrapper.$DYLIB_EXT ../../..
-echo Build success
+
+run cp "build/libquickjs-java-wrapper.$DYLIB_EXT" ../../..
+
+echo "Build success"

--- a/build-jni.sh
+++ b/build-jni.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+cd wrapper-java/src/main
+if [ -d build ]; then
+    echo "Deleting old build folder..."
+    rm -rf build
+fi
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake --build build
+OS_NAME=$(uname)
+if [[ "$OS_NAME" == "Darwin" ]]; then
+    DYLIB_EXT="dylib"   # macOS
+else
+    DYLIB_EXT="so"      # Linux
+fi
+cp build/libquickjs-java-wrapper.$DYLIB_EXT ../../..
+echo Build success

--- a/native/cpp/quickjs_wrapper.cpp
+++ b/native/cpp/quickjs_wrapper.cpp
@@ -129,7 +129,10 @@ static void jsFuncCallbackFinalizer(JSRuntime *rt, JSValue val) {
 
 static JSClassDef js_func_callback_class = {
         "JSFuncCallback",
-        .finalizer = jsFuncCallbackFinalizer,
+        jsFuncCallbackFinalizer,
+        nullptr,
+        nullptr,
+        nullptr
 };
 
 static JSValue jsFnCallback(JSContext *ctx,

--- a/wrapper-java/src/main/CMakeLists.txt
+++ b/wrapper-java/src/main/CMakeLists.txt
@@ -16,5 +16,6 @@ add_library( # Sets the name of the library.
 
 
 include_directories($ENV{JAVA_HOME}/include/)
+include_directories($ENV{JAVA_HOME}/include/win32)
 include_directories($ENV{JAVA_HOME}/include/darwin)
 include_directories($ENV{JAVA_HOME}/include/linux)


### PR DESCRIPTION
## Summary by Sourcery

添加跨平台构建脚本和配置更新，用于构建 JNI 共享库，包括对 Windows 的支持以及构建流程文档。

新功能：
- 引入 shell 和 batch 脚本，用于在 Linux、macOS 和 Windows 上构建 JNI 共享库。

改进：
- 在 README 中记录 JNI 构建的前置条件以及各平台的构建命令。
- 调整 JNI 的 CMake 配置和本地包装器类定义，以改进跨平台兼容性，包括 Windows 的头文件包含路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add cross-platform build scripts and configuration updates for building the JNI shared library, including Windows support and documentation for the build process.

New Features:
- Introduce shell and batch scripts to build the JNI shared library on Linux, macOS, and Windows.

Enhancements:
- Document the JNI build prerequisites and platform-specific build commands in the README.
- Adjust JNI CMake configuration and native wrapper class definition to improve cross-platform compatibility, including Windows include paths.

</details>